### PR TITLE
Update main to unminified version, so bower does not compain

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angulartics-segment",
-  "main": "./dist/angulartics-segment.min.js",
+  "main": "./lib/angulartics-segment.js",
   "version": "0.2.0",
   "dependencies": {
     "angulartics": "^1.1.0"


### PR DESCRIPTION
Fixes `invalid-meta The "main" field cannot contain minified files` issue with bower.
