### PR TITLE
Add setUsername method and change setUserProperties signature

### DIFF
--- a/lib/angulartics-segment.js
+++ b/lib/angulartics-segment.js
@@ -62,12 +62,23 @@ angular.module('angulartics.segment', ['angulartics'])
         }
       }
     });
+    // https://segment.com/docs/libraries/analytics.js/#identify
+    // analytics.identify([userId], [traits], [options], [callback]);
+    $analyticsProvider.registerSetUsername(function (userId) {
+      try {
+        analytics.identify(userId);
+      } catch (e) {
+        if (!(e instanceof ReferenceError)) {
+          throw e;
+        }
+      }
+    });
 
     // https://segment.com/docs/libraries/analytics.js/#identify
     // analytics.identify([userId], [traits], [options], [callback]);
-    $analyticsProvider.registerSetUserProperties(function (userId, traits, options, callback) {
+    $analyticsProvider.registerSetUserProperties(function (traits, options, callback) {
       try {
-        analytics.identify(userId, traits, options, callback);
+        analytics.identify(traits, options, callback);
       } catch (e) {
         if (!(e instanceof ReferenceError)) {
           throw e;


### PR DESCRIPTION
For Issue #21 

This PR adds a setUsername method to the plugin and removes the userId argument from the setUserProperties method.

As I mentioned in the issue, this is a breaking change due to the setUserProperties signature change, but it does allow this plugin to play nicely with other angulartics plugins.

Also not sure if you want the built dist files to be part of the PR or not.